### PR TITLE
Fix argv

### DIFF
--- a/python_scripts/nr_stitcher.py
+++ b/python_scripts/nr_stitcher.py
@@ -84,7 +84,7 @@ def main():
 
     settings_file = 'stitch_settings.txt'
     if len(sys.argv) >= 1:
-        settings_files = sys.argv[0]
+        settings_file = sys.argv[1]
 
     print(f"Reading stitch settings from {settings_file}")
 


### PR DESCRIPTION
There was a typo that prevented the passed in file path to be read as settings file. Also, `argv[0]` is the name of the python script itself and `argv[1]` is the first real argument.