### PR TITLE
Updates and sanity checks to tomcat script

### DIFF
--- a/python_scripts/stitch_settings_from_tomcat_scans.py
+++ b/python_scripts/stitch_settings_from_tomcat_scans.py
@@ -147,7 +147,7 @@ def main():
             rec_dir = ""
             if args.recdir:
                 # Use reconstruction directory override
-                rec_dir = args.recdir % tuple(list(scan_name for _ in range(str(args.recdir).count('%s')))) # Allow the user to pass multiple %s in the string, happens sometimes
+                rec_dir = args.recdir % tuple(scan_name for _ in range(str(args.recdir).count('%s'))) # Allow the user to pass multiple %s in the string, happens sometimes
             elif 'Reconstruction Parameters Reconstruction Dir' in logDict:
                 rec_dir = parser.logDict['Reconstruction Parameters Reconstruction Dir']
             else:

--- a/python_scripts/stitch_settings_from_tomcat_scans.py
+++ b/python_scripts/stitch_settings_from_tomcat_scans.py
@@ -2,11 +2,12 @@
 
 import argparse
 import glob
+import json
 import re
 import os
 from logFileParser import logFileParser
 
-from default_stitch_settings import *
+from default_stitch_settings import write_stitch_settings
 
 def natural_sort_key(s, nsre=re.compile('([0-9]+)')):
     """
@@ -22,12 +23,14 @@ def main():
         argsparser = argparse.ArgumentParser(description='Creates input file for nr_stitcher.py program from TOMCAT scan log files. Saves the log file to the current directory and assumes that the input sub-images are also saved to the current folder.')
         argsparser.add_argument('scan_folders', nargs='*', type=str, help='Specify path that corresponds to base folder of each sub-scan. The base folder is the folder that contains sub-folders tif, rec_16bit_Paganin_0 etc. Use glob syntax to select multiple directories or pass multiple entries separated by space. Specify folders that contain the original scan log file in subdirectory tif.')
         argsparser.add_argument('-b', '--binning', default=1, type=int, help='Binning that is to be applied before stitching.')
+        argsparser.add_argument('-j', '--json', action='store_true', help='Set to true to use the logs from json files. Default is False.')
         argsparser.add_argument('-n', '--name', default='stitched', type=str, help='Sample name.')
-        argsparser.add_argument('-r', '--recdir', default='', type=str, help='Try to find reconstructions from this directory. Use e.g. if the reconstructions were done in Ra and the original log files do not contain reconstruction folder. String %%s will be replaced by sub-scan name, e.g. /das/work/p1234/Data10/disk1/%%s/ may expand to /das/work/p1234/Data10/disk1/01_BigSample_B7/')
+        argsparser.add_argument('-r', '--recdir', default='', type=str, help='Try to find reconstructions from this directory. Use e.g. if the reconstructions were done in Ra and the original log files do not contain reconstruction folder. String %%s will be replaced by sub-scan name, e.g. /das/work/p1234/Data10/disk1/%%s/ may expand to /das/work/p1234/Data10/disk1/01_BigSample_B7/. Can be used multiple times, e.g. /das/work/p1234/Data10/disk1/%%s/%%s/ expands to /das/work/p1234/Data10/disk1/01_BigSample_B7/01_BigSample_B7/')
         argsparser.add_argument('-m', '--mask', action='store_true', help='Set to true to mask the input images to the maximum inscribed circle in each cross-section. Use this setting to erase possible bad data outside of the well-reconstructed region.')
-        argsparser.add_argument('-u', '--units', default='um', type=str, help='Units used for sample coordinates in the log files. Can be mm or um.')
-        argsparser.add_argument('-xx', '--xx_sign', default='positive', type=str, help='Sign of the XX coordinate. Can be "positive" or "negative"')
-        argsparser.add_argument('-zz', '--zz_sign', default='positive', type=str, help='Sign of the ZZ coordinate. Can be "positive" or "negative"')
+        argsparser.add_argument('-u', '--units', default='um', type=str, help='Units used for sample coordinates in the log files. Can be mm or um.', choices=['mm', 'um'])
+        argsparser.add_argument('-xx', '--xx_sign', default='positive', type=str, help='Sign of the XX coordinate. Can be "positive" or "negative"', choices=['positive', 'negative'])
+        argsparser.add_argument('-zz', '--zz_sign', default='positive', type=str, help='Sign of the ZZ coordinate. Can be "positive" or "negative"', choices=['positive', 'negative'])
+        argsparser.add_argument('--valid_scans', nargs='*', default='', type=str, help='Specify valid scans to be stitched.')
 
 
         args = argsparser.parse_args()
@@ -63,12 +66,12 @@ def main():
         logs = []
         for folder in args.scan_folders:
             if not os.path.isfile(folder):
-                logglob = f"{folder}/tif/*.log"
+                logglob = f"{folder}/tif/*.json" if args.json else f"{folder}/tif/*.log"
                 files = glob.glob(logglob)
                 if len(files) > 0:
                     logs.extend(files)
                 else:
-                    logglob = f"{folder}/*.log"
+                    logglob = f"{folder}/*.json" if args.json else f"{folder}/*.log"
                     files = glob.glob(logglob)
                     if len(files) > 0:
                         logs.extend(files)
@@ -77,11 +80,15 @@ def main():
             else:
                 # folder is actually file name. We assume that it is name of log file to be stitched.
                 # Skip non-supported log files (like .h5 files that often get into the folder list)
-                if folder.endswith('xml') or folder.endswith('log'):
+                if folder.endswith('xml') or folder.endswith('json' if args.json else 'log'):
                     logs.append(folder)
 
         # Remove '_dacatXXX.log' entries
         logs = [p for p in logs if '_dacat' not in p]
+
+        if args.json:
+            # Remove '_config.json entries
+            logs = [p for p in logs if '_config' not in p]
 
         # Normalize paths
         logs = [os.path.normpath(p) for p in logs]
@@ -94,7 +101,7 @@ def main():
         
 
         if len(logs) <= 0:
-            raise SystemExit(f"No log files found.")
+            raise SystemExit("No log files found.")
 
         first_x = 0
         first_y = 0
@@ -102,24 +109,46 @@ def main():
 
         good_count = 0
         positions = ""
+
+        def is_valid_scan(log_file_path):
+            for scan in args.valid_scans:
+                if scan in log_file_path:
+                    return True
+            return False
+        
         for logfile in logs:
+            # Check if the scan is valid
+            if args.valid_scans and not is_valid_scan(logfile):
+                continue
             # Read log file
             print(f"Reading log from {logfile}...")
-            parser = logFileParser()
-            parser.parser_input(logfile)
+            if args.json:
+                with open(logfile, 'r') as f:
+                    logDict = json.load(f)
+                scan_name = logDict['scientificMetadata']['scanParameters']['File Prefix']
+                pixel_size = logDict['scientificMetadata']['detectorParameters']['Actual pixel size']['v']
+                xx = logDict['scientificMetadata']['scanParameters']['Sample holder XX-position']['v']
+                zz = logDict['scientificMetadata']['scanParameters']['Sample holder ZZ-position']['v']
+                y = logDict['scientificMetadata']['scanParameters']['Sample holder Y-position']['v']
+                gigafrost = logDict['scientificMetadata']['detectorParameters']['Camera'] == 'GigaFRoST'
+            else:
+                parser = logFileParser()
+                parser.parser_input(logfile)
 
-            scan_name = parser.logDict['Scan Settings File Prefix']
-            pixel_size = parser.logDict['Detector Settings Actual pixel size [um]']
-            xx = parser.logDict['Sample user coordinates XX-coordinate']
-            zz = parser.logDict['Sample user coordinates ZZ-coordinate']
-            y = parser.logDict['Sample user coordinates Y-coordinate']
-            gigafrost = parser.logDict['Detector Settings Camera'] == 'GigaFRoST'
+                logDict = parser.logDict
+
+                scan_name = logDict['Scan Settings File Prefix']
+                pixel_size = logDict['Detector Settings Actual pixel size [um]']
+                xx = logDict['Sample user coordinates XX-coordinate']
+                zz = logDict['Sample user coordinates ZZ-coordinate']
+                y = logDict['Sample user coordinates Y-coordinate']
+                gigafrost = logDict['Detector Settings Camera'] == 'GigaFRoST'
             
             rec_dir = ""
             if args.recdir:
                 # Use reconstruction directory override
-                rec_dir = args.recdir % scan_name
-            elif 'Reconstruction Parameters Reconstruction Dir' in parser.logDict:
+                rec_dir = args.recdir % tuple(list(scan_name for _ in range(str(args.recdir).count('%s')))) # Allow the user to pass multiple %s in the string, happens sometimes
+            elif 'Reconstruction Parameters Reconstruction Dir' in logDict:
                 rec_dir = parser.logDict['Reconstruction Parameters Reconstruction Dir']
             else:
                 #raise Exception(f"No reconstruction directory found from log file {logfile}, and no reconstruction directory override specified. Consider using --recdir command line argument.")
@@ -160,7 +189,7 @@ def main():
                 Z -= first_z
 
                 # Normalize rec_dir path and make sure it exists
-                rec_dir = os.path.normpath(rec_dir)+ f"/rec_16bit_Paganin"
+                rec_dir = os.path.normpath(rec_dir)#+ f"/rec_16bit_Paganin"
 
                 rec_dir2 = os.path.dirname(logfile) + os.path.sep + ".." + os.path.sep + os.path.basename(rec_dir)
                 rec_dir2 = os.path.normpath(rec_dir2)


### PR DESCRIPTION
- Added possibility of parsing scan positions from json files (key names seem to be more consistent across detectors)
- Now recdir argument accepts multiple '%s' (see helpstring, useful when reconstructions go to ra directly)
- Added choices to 'units', 'xx_sign' and 'zz_sign' parameters to ensure the CLI throws an error if these arguments are not used correctly.
- Added 'valid_scans' parameter to specify a list of strings the parsed paths must contain to be stitched (any of them must be present). It is useful for debugging when there are many scans to stitch.
- Commented out the addition of the string '/rec_16bit_Paganin' in L192 since the reconstructions are sometimes named 'rec_16bit_phase' and this can be specified using the 'recdir' parameter.